### PR TITLE
Reoder dependency installation

### DIFF
--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -232,7 +232,7 @@ async function installBatchedPackages(batches) {
                 shelljs.exec(`cp packages/${pkg.name}/${file} ${copyTo}`);
               } else {
                 // Handle folders
-                shelljs.exec(`cp -R packages/${pkg.name}/${file}/ ${copyTo}`);
+                shelljs.exec(`cp -R packages/${pkg.name}/${file}/ ${copyTo}/`);
               }
             });
           }

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -204,21 +204,21 @@ async function installBatchedPackages(batches) {
           shelljs.exec(
             `mkdir -p packages/${pkg.dependents[k]}/node_modules/${pkg.name}`
           );
-          // If there are no package files copy everything
-          if (!pkg.files) {
-            shelljs.exec(`
+          // Copy the entire module for now for correctness.
+          // if (!pkg.files) {
+          shelljs.exec(`
               cp -R packages/${pkg.name}/ packages/${
-              pkg.dependents[k]
-            }/node_modules/${pkg.name}`);
-          } else {
-            // Otherwise copy only the package files
-            ['package.json', ...pkg.files].forEach(file => {
-              shelljs.exec(`
-              cp -R packages/${pkg.name}/${file} packages/${
-                pkg.dependents[k]
-              }/node_modules/${pkg.name}/${file}`);
-            });
-          }
+            pkg.dependents[k]
+          }/node_modules/${pkg.name}`);
+          // } else {
+          //   // Otherwise copy only the package files
+          //   ['package.json', ...pkg.files].forEach(file => {
+          //     shelljs.exec(`
+          //     cp -R packages/${pkg.name}/${file} packages/${
+          //       pkg.dependents[k]
+          //     }/node_modules/${pkg.name}/${file}`);
+          //   });
+          // }
         }
       })
     );

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -205,7 +205,7 @@ async function installBatchedPackages(batches) {
         if (pkg.scripts.transpile) {
           console.log(`${pkg.name} - transpiling`);
           shelljs.exec(
-            `cd packages/${pkg.name} && ./node_modules/.bin/cup build`
+            `cd packages/${pkg.name} && yarn transpile`
           );
         }
 

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -232,7 +232,7 @@ async function installBatchedPackages(batches) {
                 shelljs.exec(`cp packages/${pkg.name}/${file} ${copyTo}`);
               } else {
                 // Handle folders
-                shelljs.exec(`cp -R packages/${pkg.name}/${file}/ ${copyTo}/`);
+                shelljs.exec(`cp -R packages/${pkg.name}/${file}/. ${copyTo}/`);
               }
             });
           }

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -170,7 +170,27 @@ function topologicallyBatchPackages(allPackages, {rejectCycles} = {}) {
   return batches;
 }
 
+function execAndOutput(command) {
+  console.log(`exec: ${command}`);
+  shelljs.exec(command);
+}
+
 async function installBatchedPackages(batches) {
+  // Install non-fusion dependencies for all packages first.
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    await Promise.all(
+      batch.map(async pkg => {
+        console.log(chalk.bold.blue(`${pkg.name} - installing dependencies`));
+        shelljs.exec(
+          `cd packages/${pkg.name} && \
+        npm install ${Object.keys(pkg.nonFusionDependencies).join(' ')}`,
+          {silent: true}
+        );
+      })
+    );
+  }
+
   for (let i = 0; i < batches.length; i++) {
     const batch = batches[i];
     console.log(
@@ -182,18 +202,12 @@ async function installBatchedPackages(batches) {
     // Process each batch of dependencies in parallel.
     await Promise.all(
       batch.map(async pkg => {
-        console.log(chalk.bold.blue(`${pkg.name} - installing dependencies`));
-        // Install with NPM as running yarn-add will also install the fusion dependencies we don't want.
-        shelljs.exec(
-          `cd packages/${pkg.name} && \
-          npm install ${Object.keys(pkg.nonFusionDependencies).join(' ')}`,
-          {silent: true}
-        );
-
         // If we have a transpile script, transpile then copy to all other dependent packages
         if (pkg.scripts.transpile) {
           console.log(`${pkg.name} - transpiling`);
-          shelljs.exec(`cd packages/${pkg.name} && yarn transpile`);
+          shelljs.exec(
+            `cd packages/${pkg.name} && ./node_modules/.bin/cup build`
+          );
         }
 
         // Copy into all dependents
@@ -201,24 +215,33 @@ async function installBatchedPackages(batches) {
           console.log(
             `${pkg.name} - copying into dependent ${pkg.dependents[k]}`
           );
-          shelljs.exec(
-            `mkdir -p packages/${pkg.dependents[k]}/node_modules/${pkg.name}`
-          );
-          // Copy the entire module for now for correctness.
-          // if (!pkg.files) {
-          shelljs.exec(`
+          // If there are no package files copy everything
+          if (!pkg.files) {
+            execAndOutput(`
               cp -R packages/${pkg.name}/ packages/${
-            pkg.dependents[k]
-          }/node_modules/${pkg.name}`);
-          // } else {
-          //   // Otherwise copy only the package files
-          //   ['package.json', ...pkg.files].forEach(file => {
-          //     shelljs.exec(`
-          //     cp -R packages/${pkg.name}/${file} packages/${
-          //       pkg.dependents[k]
-          //     }/node_modules/${pkg.name}/${file}`);
-          //   });
-          // }
+              pkg.dependents[k]
+            }/node_modules/${pkg.name}`);
+          } else {
+            // Otherwise copy only the package files
+            execAndOutput(
+              `mkdir -p packages/${pkg.dependents[k]}/node_modules/${pkg.name}`
+            );
+            ['package.json', ...pkg.files].forEach(file => {
+              const copyTo = `packages/${pkg.dependents[k]}/node_modules/${
+                pkg.name
+              }/${file}`;
+              // If file just copy
+              if (file.includes('.')) {
+                execAndOutput(`cp packages/${pkg.name}/${file} ${copyTo}`);
+              } else {
+                // Handle folders
+                execAndOutput(`cp -R packages/${pkg.name}/${file}/ ${copyTo}`);
+              }
+            });
+          }
+          execAndOutput(
+            `ls -la packages/${pkg.dependents[k]}/node_modules/${pkg.name}/`
+          );
         }
       })
     );

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -204,9 +204,7 @@ async function installBatchedPackages(batches) {
         // If we have a transpile script, transpile then copy to all other dependent packages
         if (pkg.scripts.transpile) {
           console.log(`${pkg.name} - transpiling`);
-          shelljs.exec(
-            `cd packages/${pkg.name} && yarn transpile`
-          );
+          shelljs.exec(`cd packages/${pkg.name} && yarn transpile`);
         }
 
         // Copy into all dependents

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -207,7 +207,7 @@ async function installBatchedPackages(batches) {
           // If there are no package files copy everything
           if (!pkg.files) {
             shelljs.exec(`
-              cp -R packages/${pkg.name} packages/${
+              cp -R packages/${pkg.name}/ packages/${
               pkg.dependents[k]
             }/node_modules/${pkg.name}`);
           } else {

--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -183,9 +183,10 @@ async function installBatchedPackages(batches) {
     await Promise.all(
       batch.map(async pkg => {
         console.log(chalk.bold.blue(`${pkg.name} - installing dependencies`));
+        // Install with NPM as running yarn-add will also install the fusion dependencies we don't want.
         shelljs.exec(
           `cd packages/${pkg.name} && \
-          yarn add ${Object.keys(pkg.nonFusionDependencies).join(' ')}`,
+          npm install ${Object.keys(pkg.nonFusionDependencies).join(' ')}`,
           {silent: true}
         );
 


### PR DESCRIPTION
Installing dependencies after we copy previous plugins causes them to disappear. Moving the ordering around appears to fix things.

Fixes #9 