### PR TITLE
Update Github PR status after verification run

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+echo "Exit status is ${BUILDKITE_COMMAND_EXIT_STATUS}"
+
+if [ $BUILDKITE_COMMAND_EXIT_STATUS != "0" ]; then
+  buildkite-agent meta-data set "status" "failure"
+else
+  echo "Step passed."
+fi

--- a/.buildkite/verification.yml
+++ b/.buildkite/verification.yml
@@ -288,3 +288,14 @@ steps:
     plugins:
       "docker-compose#v1.5.2":
         run: "fusion-release"
+  - wait: ~
+    continue_on_failure: true
+  - name: "Update Github status"
+    command: "bin/afterVerification"
+    branches: master
+    timeout_in_minutes: 60
+    agents:
+      queue: workers
+    plugins:
+      "docker-compose#v1.5.2":
+        run: "fusion-release"

--- a/bin/afterVerification
+++ b/bin/afterVerification
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+require('../src/afterVerification')();

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.test
+    environment:
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_BUILD_URL
     volumes:
       - '.:/fusion-release-test'
       - /fusion-release-test/node_modules/
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,12 @@ version: '2'
 services:
   fusion-release:
     build: .
+    environment:
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_BUILD_URL
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
-      # - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "clean": "rm -rf packages",
     "bootstrap": "node src/index",
     "verify": "lerna exec --concurrency 1 -- yarn test",
-    "test": "jest ."
+    "test": "jest"
   },
   "author": "Kevin Grandon <keving@uber.com>",
   "license": "MIT",
   "dependencies": {
+    "@octokit/rest": "^15.2.6",
     "chalk": "^2.3.1",
     "fusion-orchestrate": "^1.0.4",
     "lerna": "^2.9.0",
@@ -36,6 +37,6 @@
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
     },
-    "testRegex": "src/__tests__/.*.test.js"
+    "testRegex": "src/__tests__/.*.test.js$"
   }
 }

--- a/src/__tests__/__snapshots__/afterVerification.test.js.snap
+++ b/src/__tests__/__snapshots__/afterVerification.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`afterVerification failure - updates github status 1`] = `
+Object {
+  "context": "probot/release-verification",
+  "description": "Verification build resulted in success",
+  "owner": "TEST_OWNER",
+  "repo": "TEST_REPO",
+  "sha": "TEST_SHA",
+  "state": "success",
+  "target_url": "http://buildkite...",
+}
+`;
+
+exports[`afterVerification success - updates github status 1`] = `
+Object {
+  "context": "probot/release-verification",
+  "description": "Verification build resulted in failure",
+  "owner": "TEST_OWNER",
+  "repo": "TEST_REPO",
+  "sha": "TEST_SHA",
+  "state": "failure",
+  "target_url": "http://buildkite...",
+}
+`;

--- a/src/__tests__/afterVerification.test.js
+++ b/src/__tests__/afterVerification.test.js
@@ -1,0 +1,51 @@
+/* eslint-env jest, node */
+
+const afterVerification = require('../afterVerification');
+
+// Mock buildkite agent meta-data calls
+jest.mock('shelljs', () => {
+  const __commandMock__ = jest.fn();
+  return {
+    __commandMock__,
+    exec: command => {
+      if (command.includes('"prerelease"')) {
+        return false;
+      } else if (command.includes('"release-pr-head-sha"')) {
+        return 'TEST_SHA';
+      } else if (command.includes('"release-pr-head-repo-full-name"')) {
+        return 'TEST_OWNER/TEST_REPO';
+      } else if (command.includes('"status"')) {
+        return __commandMock__();
+      }
+    },
+  };
+});
+
+jest.mock('@octokit/rest', () => {
+  const createStatus = jest.fn();
+  return () => ({
+    authenticate: () => {},
+    repos: {
+      createStatus,
+    },
+  });
+});
+
+const octokit = require('@octokit/rest');
+const {__commandMock__} = require('shelljs');
+
+describe('afterVerification', () => {
+  test('success - updates github status', async () => {
+    process.env.BUILDKITE_BUILD_URL = 'http://buildkite...';
+    __commandMock__.mockReturnValueOnce('success');
+    afterVerification();
+    expect(octokit().repos.createStatus.mock.calls[0][0]).toMatchSnapshot();
+  });
+
+  test('failure - updates github status', async () => {
+    process.env.BUILDKITE_BUILD_URL = 'http://buildkite...';
+    __commandMock__.mockReturnValueOnce('failure');
+    afterVerification();
+    expect(octokit().repos.createStatus.mock.calls[1][0]).toMatchSnapshot();
+  });
+});

--- a/src/afterVerification.js
+++ b/src/afterVerification.js
@@ -1,0 +1,49 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
+const shelljs = require('shelljs');
+
+const octokit = require('@octokit/rest')({
+  timeout: 0,
+  requestMedia: 'application/vnd.github.v3+json',
+  headers: {
+    'user-agent': 'octokit/rest.js v1.2.3',
+  },
+});
+
+octokit.authenticate({
+  type: 'token',
+  token: process.env.GITHUB_TOKEN,
+});
+
+module.exports = async function afterVerification() {
+  const isPrerelease = shelljs.exec(
+    'buildkite-agent meta-data get "prerelease"'
+  );
+
+  // No need to update statuses for prereleases.
+  if (isPrerelease === 'true') {
+    return;
+  }
+
+  const statusMetadata = shelljs.exec('buildkite-agent meta-data get "status"');
+  const sha = shelljs.exec(
+    'buildkite-agent meta-data get "release-pr-head-sha"'
+  );
+  const [owner, repo] = shelljs
+    .exec('buildkite-agent meta-data get "release-pr-head-repo-full-name"')
+    .split('/');
+
+  const newState = statusMetadata == 'failure' ? 'success' : 'failure';
+  console.log(`Updating Buildkite verification status to ${newState}`);
+
+  await octokit.repos.createStatus({
+    owner,
+    repo,
+    sha,
+    state: newState,
+    target_url: process.env.BUILDKITE_BUILD_URL,
+    description: `Verification build resulted in ${newState}`,
+    context: 'probot/release-verification',
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,19 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@octokit/rest@^15.2.6":
+  version "15.2.6"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-15.2.6.tgz#16226f58fbf0ba88f631848fb622dfe0ad410c0c"
+  dependencies:
+    before-after-hook "^1.1.0"
+    btoa-lite "^1.0.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.0"
+    lodash "^4.17.4"
+    node-fetch "^2.1.1"
+    url-template "^2.0.8"
+
 JSONStream@^1.0.4:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"
@@ -128,7 +141,7 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
 
-agent-base@^4.1.0:
+agent-base@4, agent-base@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
   dependencies:
@@ -532,6 +545,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+before-after-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
+
 block-stream@*:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
@@ -603,6 +620,10 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -1113,15 +1134,15 @@ dateformat@^1.0.11, dateformat@^1.0.12:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -2202,6 +2223,13 @@ html-encoding-sniffer@^1.0.2:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -2221,6 +2249,13 @@ http-signature@~1.2.0:
 https-proxy-agent@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
+https-proxy-agent@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
@@ -3393,6 +3428,10 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
* Adds a buildkite hook that sets job metadata for whether or not tests are passing.
* Updates Girthub release PR status based on build metadata.

Related PR: https://github.com/fusionjs/probot-app-workflow/pull/75

Fixes #32