### PR TITLE
Add missing dependencies for linked fusion packages

### DIFF
--- a/src/__tests__/bootstrap.test.js
+++ b/src/__tests__/bootstrap.test.js
@@ -1,15 +1,27 @@
+/* eslint-env node */
 /* eslint-env jest */
 
+const fs = require('fs');
 const shelljs = require('shelljs');
 const {bootstrap} = require('../bootstrap');
 
 describe('botstrap', () => {
   test('builds and installs modules correctly', async () => {
     const allPackages = ['pub/a', 'pub/b'];
+
+    // The pub/b package should not have `nop` listed.
+    const packageBJson = require('./fixture/pub/b/package.json');
+    expect(packageBJson.dependencies.nop).toBe(undefined);
+
     await bootstrap(allPackages, 'src/__tests__/fixture');
 
     const output = shelljs.exec('node src/__tests__/fixture/pub/b/index.js');
     expect(output.stdout).toBe('dep: a\n');
+
+    // Should bring along package dependencies (currently the nop module)
+    expect(
+      fs.existsSync(__dirname + '/fixture/pub/b/node_modules/nop/index.js')
+    ).toBe(true);
   });
   test('builds and installs scoped packages', async () => {
     const allPackages = ['priv/c', 'priv/d'];

--- a/src/__tests__/fixture/pub/a/package.json
+++ b/src/__tests__/fixture/pub/a/package.json
@@ -2,12 +2,11 @@
   "name": "a",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
-    "fusion-core": "^1.2.0"
+    "fusion-core": "^1.2.0",
+    "nop": "1.0.0"
   },
   "scripts": {
     "transpile": "mkdir -p dist && cp index.js dist/"

--- a/src/__tests__/fixture/pub/a/yarn.lock
+++ b/src/__tests__/fixture/pub/a/yarn.lock
@@ -46,11 +46,7 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-
-depd@^1.1.0, depd@~1.1.1:
+depd@^1.1.0, depd@~1.1.1, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
 
@@ -75,8 +71,8 @@ fresh@^0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
 fusion-core@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.2.0.tgz#afb49e4ebc6f7842768ad7a38d0365dc9c1b074e"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/fusion-core/-/fusion-core-1.2.2.tgz#bfa6bae6ee8df72db08bc1b99452e2336c317c60"
   dependencies:
     koa "^2.4.1"
     koa-compose "^4.0.0"
@@ -93,13 +89,13 @@ http-assert@^1.1.0:
     http-errors "~1.6.1"
 
 http-errors@^1.2.8, http-errors@~1.6.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   dependencies:
-    depd "1.1.1"
+    depd "~1.1.2"
     inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 inherits@2.0.3:
   version "2.0.3"
@@ -216,6 +212,10 @@ node-mocks-http@^1.6.6:
     range-parser "^1.2.0"
     type-is "^1.6.14"
 
+nop@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nop/-/nop-1.0.0.tgz#cb46cf7e01574aa6390858149f66897afe53c9ca"
+
 on-finished@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
@@ -234,11 +234,11 @@ range-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
 
-"statuses@>= 1.3.1 < 2", statuses@^1.2.0:
+"statuses@>= 1.4.0 < 2", statuses@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 

--- a/src/__tests__/fixture/pub/b/package.json
+++ b/src/__tests__/fixture/pub/b/package.json
@@ -2,9 +2,7 @@
   "name": "b",
   "version": "1.0.0",
   "main": "dist/index.js",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "dependencies": {
     "a": "^1.0.0",


### PR DESCRIPTION
Possible fix for #39

This is starting to get hairy though so maybe we can land this as a workaround while we iterate on yarn workspaces.