### PR TITLE
Revert "Ensure non-fusion dev deps are installed using --dev flag"

### DIFF
--- a/src/packageUtils.js
+++ b/src/packageUtils.js
@@ -237,7 +237,7 @@ class PackageUtils {
           });
           if (deps) {
             console.log(`${pkg.getPath()} - installing dependencies: ${deps}`);
-            shelljs.exec(`cd ${path} && npm install ${deps} --no-save`);
+            shelljs.exec(`cd ${path} && yarn add ${deps}`);
           }
         })
       );


### PR DESCRIPTION
This reverts commit 497137c9d643db33f14a0916d269810a9b88f89a.

Testing revert: https://buildkite.com/uberopensource/fusion-release-verification/builds/264

Think this broke some tests here: https://buildkite.com/uberopensource/fusion-release-verification/builds/261#59017a5d-2328-4217-8cc4-755fd9cf5ffb