### PR TITLE
Expose BUILDKITE_PIPELINE_SLUG to running docker containers

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   fusion-release-test:
-    network_mode: "host"
+    network_mode: 'host'
     build:
       context: .
       dockerfile: Dockerfile.test
@@ -11,6 +11,7 @@ services:
       - BUILDKITE_BUILD_ID
       - BUILDKITE_BUILD_NUMBER
       - BUILDKITE_BUILD_URL
+      - BUILDKITE_PIPELINE_SLUG
     volumes:
       - '.:/fusion-release-test'
       - /fusion-release-test/node_modules/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - BUILDKITE_BUILD_NUMBER
       - BUILDKITE_BUILD_URL
       - BUILDKITE_API_TOKEN
+      - BUILDKITE_PIPELINE_SLUG
       - GITHUB_TOKEN
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'


### PR DESCRIPTION
This will allow us to know when things are running in release verification.