### PR TITLE
Avoid updating pull requests status for verification in non-blocking runs

### DIFF
--- a/src/__tests__/prVerification.test.js
+++ b/src/__tests__/prVerification.test.js
@@ -16,8 +16,8 @@ jest.mock('shelljs', () => {
   return {
     __commandMock__,
     exec: command => {
-      if (command.includes('"prerelease"')) {
-        return false;
+      if (command.includes('"is-release-pr"')) {
+        return true;
       } else if (command.includes('"release-pr-head-sha"')) {
         return 'TEST_SHA';
       } else if (command.includes('"release-pr-base-repo-full-name"')) {

--- a/src/afterVerification.js
+++ b/src/afterVerification.js
@@ -26,12 +26,12 @@ octokit.authenticate({
 
 module.exports = async function afterVerification() {
   const statusMetadata = shelljs.exec('buildkite-agent meta-data get "status"');
-  const isPrerelease = shelljs.exec(
-    'buildkite-agent meta-data get "prerelease"'
+  const isNonBlocking = shelljs.exec(
+    'buildkite-agent meta-data get "release-pr-non-blocking"'
   );
 
-  // No need to update statuses for prereleases or when there is no status.
-  if (isPrerelease === 'true' || statusMetadata === '') {
+  // No need to update statuses when verification is tagged as non-blocking or when there is no status.
+  if (isNonBlocking === 'true' || statusMetadata === '') {
     return;
   }
 
@@ -47,7 +47,7 @@ module.exports = async function afterVerification() {
   console.log(`Owner: ${owner}`);
   console.log(`Repo: ${repo}`);
   console.log(`Sha: ${sha}`);
-  console.log(`Targe URL: ${String(process.env.BUILDKITE_BUILD_URL)}`);
+  console.log(`Target URL: ${String(process.env.BUILDKITE_BUILD_URL)}`);
 
   await octokit.repos.createStatus({
     owner,

--- a/src/afterVerification.js
+++ b/src/afterVerification.js
@@ -26,12 +26,12 @@ octokit.authenticate({
 
 module.exports = async function afterVerification() {
   const statusMetadata = shelljs.exec('buildkite-agent meta-data get "status"');
-  const isNonBlocking = shelljs.exec(
-    'buildkite-agent meta-data get "release-pr-non-blocking"'
+  const isRelease = shelljs.exec(
+    'buildkite-agent meta-data get "is-release-pr"'
   );
 
-  // No need to update statuses when verification is tagged as non-blocking or when there is no status.
-  if (isNonBlocking === 'true' || statusMetadata === '') {
+  // No need to update statuses when verification is not for a release or when there is no status.
+  if (!isRelease || statusMetadata === '') {
     return;
   }
 


### PR DESCRIPTION
Related to [probot-app-workflow PR#129](https://github.com/fusionjs/probot-app-workflow/pull/129) that runs Fusion.js verification on all PRs.