### PR TITLE
Ignore graphql module due to flow@0.89 errors

### DIFF
--- a/flow-typed/npm/graphql.js
+++ b/flow-typed/npm/graphql.js
@@ -1,0 +1,6 @@
+// @flow
+// Temporarily ignore graphql js lib until fixes in graphql@14.0.3 is released
+// Corresponding reference in .flowconfig should be removed along with this.
+declare module 'graphql' {
+  declare module.exports: any;
+}

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -113,6 +113,9 @@ module.exports.bootstrap = async (
   `);
   const flowConfig = `[ignore]
 .*src/fixtures/failure.*
+# Temporarily ignore graphql js libs until fixes in graphql@14.0.3 are released
+# Corresponding reference in flow-typed/npm should be removed along with this.
+.*node_modules/graphql/.*
 
 [include]
 
@@ -134,6 +137,9 @@ module.exports.bootstrap = async (
   } catch (e) {
     console.log('Could not create directory', e);
   }
+
+  await exec(`cp -Rf flow-typed/npm/* ${root}/flow-typed/npm/. || true`);
+
   await Promise.all(
     allPackages.map(async dir => {
       try {


### PR DESCRIPTION
This is a temporary fix and we should remove the graphql stub once a working version is published.