### PR TITLE
Revert "Ignore graphql module due to flow@0.89 errors"

### DIFF
--- a/flow-typed/npm/graphql.js
+++ b/flow-typed/npm/graphql.js
@@ -1,6 +1,0 @@
-// @flow
-// Temporarily ignore graphql js lib until fixes in graphql@14.0.3 is released
-// Corresponding reference in .flowconfig should be removed along with this.
-declare module 'graphql' {
-  declare module.exports: any;
-}

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -113,9 +113,6 @@ module.exports.bootstrap = async (
   `);
   const flowConfig = `[ignore]
 .*src/fixtures/failure.*
-# Temporarily ignore graphql js libs until fixes in graphql@14.0.3 are released
-# Corresponding reference in flow-typed/npm should be removed along with this.
-.*node_modules/graphql/.*
 
 [include]
 
@@ -137,9 +134,6 @@ module.exports.bootstrap = async (
   } catch (e) {
     console.log('Could not create directory', e);
   }
-
-  await exec(`cp -Rf flow-typed/npm/* ${root}/flow-typed/npm/. || true`);
-
   await Promise.all(
     allPackages.map(async dir => {
       try {


### PR DESCRIPTION
This is no longer needed with the latest graphql release.

This reverts commit f735abcec2f8976828b06b6372aefbb071ad224d.

Test plan: Kick off a test build here: https://buildkite.com/uberopensource/fusion-release-verification/builds/1249